### PR TITLE
Add ApiV18 compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,7 @@ properties, and optionaly, an environment variable name whose value can be use o
 Release notes
 -------------
 
+2.2: add support for Rudder 8.x.
 2.1: update to rundeck-core version 3.3.18-20220118 (multiple vulnerabilities fixes)
 2.0: add support for Rudder 6.x. Update to rundeck-core version 3.3 
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.rundeck-plugins</groupId>
   <artifactId>rundeck-rudder-nodes-plugin</artifactId>
-  <version>2.1</version>
+  <version>2.2</version>
   <name>Rundeck Rudder Node Plugin</name>
   <url>http://rundeck.org</url>
   <inceptionYear>2015</inceptionYear>

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
@@ -41,6 +41,7 @@ sealed trait ApiVersion { def value: String }
  */
 case object ApiV6  extends ApiVersion { val value = "6"  }
 case object ApiV12 extends ApiVersion { val value = "12" }
+case object ApiV18 extends ApiVersion { val value = "18" }
 
 
 /*

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
@@ -39,10 +39,8 @@ sealed trait ApiVersion { def value: String }
  * Auto API upgrade are not relevant, since the plugin won't
  * take advantage of them without an update.
  */
-case object ApiV6  extends ApiVersion { val value = "6"  }
 case object ApiV12 extends ApiVersion { val value = "12" }
-case object ApiV18 extends ApiVersion { val value = "18" }
-
+case object ApiLatest extends ApiVersion { val value = "latest" }
 
 /*
  * Rudder base URL, for ex: https://my.company.com/rudder/

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -67,6 +67,7 @@ object RudderAPIQuery {
     config.url.version match {
       case ApiV6  => queryNodesDetails(config, config.url.nodesApi)
       case ApiV12 => queryNodesDetails(config, config.url.nodesApi)
+      case ApiV18 => queryNodesDetails(config, config.url.nodesApi)
     }
   }
 

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -64,11 +64,7 @@ object RudderAPIQuery {
    * API Version to use.
    */
   def queryNodes(config: Configuration): Failable[Map[NodeId,NodeEntryImpl]] = {
-    config.url.version match {
-      case ApiV6  => queryNodesDetails(config, config.url.nodesApi)
-      case ApiV12 => queryNodesDetails(config, config.url.nodesApi)
-      case ApiV18 => queryNodesDetails(config, config.url.nodesApi)
-    }
+    queryNodesDetails(config, config.url.nodesApi)
   }
 
   /**

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
@@ -115,8 +115,8 @@ object RudderResourceModelSourceFactory {
     .property(PropertyUtil.string(RUDDER_BASE_URL, "Rudder base URL"
       , "The URL to access to your Rudder, for ex.: 'https://my.company.com/rudder/'", true, null))
     .property(PropertyUtil.select(API_VERSION, "API version"
-      , "The API version to use for rundeck. For Rudder up to 5.0 use '6', for more recent version use '18'", true
-      , "latest", Seq("18", "12", "6").asJava))
+      , "The API version to use for rundeck. You should use 'latest' appart for compat with older Rudder up to 7.x where version should be '12'", true
+      , "latest", Seq("latest", "12").asJava))
     .property(PropertyUtil.string(API_TOKEN, "API token"
       , "The API token to use for rundeck, defined in Rudder API administration page", true, null))
     .property(PropertyUtil.integer(API_TIMEOUT, "API timeout"
@@ -164,10 +164,9 @@ object RudderResourceModelSourceFactory {
       apiVersion <- getProp(API_VERSION).fold(
                       Left(_)
                     , x => x match {
-                        case "6"  => Right(ApiV6)
                         case "12" => Right(ApiV12)
-                        case "18" => Right(ApiV18)
-                        case _ => Left(ErrorMsg(s"The API version '${x}' is not authorized, only accepting '18'"))
+                        case "latest" => Right(ApiLatest)
+                        case _ => Left(ErrorMsg(s"The API version '${x}' is not authorized, only accepting '12' or 'latest'"))
                     }).right
     } yield {
       val envVarSSLPort = getProp(ENV_VARIABLE_SSH_PORT).fold(_ => None, x => Some(x))

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
@@ -115,8 +115,8 @@ object RudderResourceModelSourceFactory {
     .property(PropertyUtil.string(RUDDER_BASE_URL, "Rudder base URL"
       , "The URL to access to your Rudder, for ex.: 'https://my.company.com/rudder/'", true, null))
     .property(PropertyUtil.select(API_VERSION, "API version"
-      , "The API version to use for rundeck. For Rudder up to 5.0 use '6', for more recent version use '12'", true
-      , "latest", Seq("12", "6").asJava))
+      , "The API version to use for rundeck. For Rudder up to 5.0 use '6', for more recent version use '18'", true
+      , "latest", Seq("18", "12", "6").asJava))
     .property(PropertyUtil.string(API_TOKEN, "API token"
       , "The API token to use for rundeck, defined in Rudder API administration page", true, null))
     .property(PropertyUtil.integer(API_TIMEOUT, "API timeout"
@@ -166,7 +166,8 @@ object RudderResourceModelSourceFactory {
                     , x => x match {
                         case "6"  => Right(ApiV6)
                         case "12" => Right(ApiV12)
-                        case _ => Left(ErrorMsg(s"The API version '${x}' is not authorized, only accepting '12'"))
+                        case "18" => Right(ApiV18)
+                        case _ => Left(ErrorMsg(s"The API version '${x}' is not authorized, only accepting '18'"))
                     }).right
     } yield {
       val envVarSSLPort = getProp(ENV_VARIABLE_SSH_PORT).fold(_ => None, x => Some(x))


### PR DESCRIPTION
Added Rudder's APIv18 Compatibility. 

Route didn't change but on Rudder 8.0.1, all call to `/rudder/api/12/nodes` give a 404. 

Tested and works fine with Rudder 8.0.1 and Rundeck 5.3.0