### PR TITLE
Sanitize node attributes name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.rundeck-plugins</groupId>
   <artifactId>rundeck-rudder-nodes-plugin</artifactId>
-  <version>2.2</version>
+  <version>2.3</version>
   <name>Rundeck Rudder Node Plugin</name>
   <url>http://rundeck.org</url>
   <inceptionYear>2015</inceptionYear>

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -216,7 +216,7 @@ object RudderAPIQuery {
       node.setOsVersion(json.os.version.as[String])
       node.setUsername(rundeckUser)
       node.getAttributes().put("rudder_information:id", id.value)
-      node.getAttributes().put("rudder_information:node_direct_URL", config.url.nodeUrl(id))
+      node.getAttributes().put("rudder_information:node_direct_url", config.url.nodeUrl(id))
       node.getAttributes().put("rudder_information:policy_server_id", json.policyServerId.as[String])
       node.getAttributes().put("rudder_information:last_inventory_date", json.lastInventoryDate.as[String])
       node.getAttributes().put("rudder_information:node_status", json.status.as[String])
@@ -227,8 +227,8 @@ object RudderAPIQuery {
       import modes.returnTry
 
       json.os.fullName.as[String].foreach( node.setDescription )
-      json.ram.as[Int].foreach { x => node.getAttributes().put("total_RAM", x.toString) }
-      json.ipAddresses.as[List[String]].foreach { x => node.getAttributes().put("IP_Addresses", x.mkString(", ")) }
+      json.ram.as[Int].foreach { x => node.getAttributes().put("total_ram", x.toString) }
+      json.ipAddresses.as[List[String]].foreach { x => node.getAttributes().put("ip_addresses", x.mkString(", ")) }
 
       //rudder properties
       case class JsonRudderProp(name: String, value: String)
@@ -251,7 +251,7 @@ object RudderAPIQuery {
       json.networkInterfaces.as[Seq[Map[String, Json]]].foreach { _.foreach { case j =>
         j("name").as[String].foreach { name =>
           j("ipAddresses").as[Seq[String]].foreach { ips =>
-            node.getAttributes().put(s"rudder_network_interface:${name}:IP_addresses", ips.mkString(", "))
+            node.getAttributes().put(s"rudder_network_interface:${name}:ip_addresses", ips.mkString(", "))
           }
           j.filterKeys { k => k != "name" && k != "ipAddresses" }.foreach { case (k,v) =>
             v.as[String].orElse(v.as[Int]).orElse(v.as[Boolean]).foreach { value =>

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -216,10 +216,10 @@ object RudderAPIQuery {
       node.setOsVersion(json.os.version.as[String])
       node.setUsername(rundeckUser)
       node.getAttributes().put("rudder_information:id", id.value)
-      node.getAttributes().put("rudder_information:node direct URL", config.url.nodeUrl(id))
-      node.getAttributes().put("rudder_information:policy server id", json.policyServerId.as[String])
-      node.getAttributes().put("rudder_information:last inventory date", json.lastInventoryDate.as[String])
-      node.getAttributes().put("rudder_information:node status", json.status.as[String])
+      node.getAttributes().put("rudder_information:node_direct_URL", config.url.nodeUrl(id))
+      node.getAttributes().put("rudder_information:policy_server_id", json.policyServerId.as[String])
+      node.getAttributes().put("rudder_information:last_inventory_date", json.lastInventoryDate.as[String])
+      node.getAttributes().put("rudder_information:node_status", json.status.as[String])
 
 
       //these one are not - make as[XXX] return Try, so that it's easier to
@@ -227,19 +227,19 @@ object RudderAPIQuery {
       import modes.returnTry
 
       json.os.fullName.as[String].foreach( node.setDescription )
-      json.ram.as[Int].foreach { x => node.getAttributes().put("Total RAM", x.toString) }
-      json.ipAddresses.as[List[String]].foreach { x => node.getAttributes().put("IP Addresses", x.mkString(", ")) }
+      json.ram.as[Int].foreach { x => node.getAttributes().put("total_RAM", x.toString) }
+      json.ipAddresses.as[List[String]].foreach { x => node.getAttributes().put("IP_Addresses", x.mkString(", ")) }
 
       //rudder properties
       case class JsonRudderProp(name: String, value: String)
       json.properties.as[List[Option[JsonRudderProp]]].foreach { _.foreach { _.foreach { case JsonRudderProp(name, value) =>
-        node.getAttributes().put(s"Rudder Node Properties:${name}", value)
+        node.getAttributes().put(s"rudder_node_properties:${name}", value)
       } } }
 
 
       //accounts
       json.accounts.as[List[String]].foreach { accounts =>
-        node.getAttributes().put("Accounts on server", accounts.mkString(", "))
+        node.getAttributes().put("accounts_on_server", accounts.mkString(", "))
       }
 
       //env variables
@@ -251,7 +251,7 @@ object RudderAPIQuery {
       json.networkInterfaces.as[Seq[Map[String, Json]]].foreach { _.foreach { case j =>
         j("name").as[String].foreach { name =>
           j("ipAddresses").as[Seq[String]].foreach { ips =>
-            node.getAttributes().put(s"rudder_network_interface:${name}:IP addresses", ips.mkString(", "))
+            node.getAttributes().put(s"rudder_network_interface:${name}:IP_addresses", ips.mkString(", "))
           }
           j.filterKeys { k => k != "name" && k != "ipAddresses" }.foreach { case (k,v) =>
             v.as[String].orElse(v.as[Int]).orElse(v.as[Boolean]).foreach { value =>


### PR DESCRIPTION
Many node attributes generated by this plugin contain spaces. This poses a problem when retrieving these node attributes in Rundeck jobs.

For example, the command: `echo ${node.rudder_information:node status}`
Returns : 
```
bash: line 1: ${node.rudder_information:node status}: bad substitution
Failed: Unknown: Remote command failed with exit status 1
```
Replacing `node status` with `node_status`, we get: 
```
accepted
```

I don't know whether this constitutes a breaking change, normally not, as these variables were not usable to my knowledge.