### PR TITLE
Fixes #16 : Upload Rudder groups

### DIFF
--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
@@ -19,6 +19,9 @@ package com.normation.rundeck.plugin.resources.rudder
 import zio.*
 import zio.json.*
 import zio.json.ast.Json
+import zio.schema.DeriveSchema
+import zio.schema.Schema
+import zio.schema.derived
 
 /**
  * This file contains data structure definition for our model.
@@ -34,13 +37,11 @@ import zio.json.ast.Json
 sealed trait ApiVersion { def value: String }
 
 /*
- * Rationnal to not use "latest" in place of 12.
  * If you use latest with Rudder 4.x, you
  * will have a clear error, nothing works => change version.
  * Auto API upgrade are not relevant, since the plugin won't
  * take advantage of them without an update.
  */
-case object ApiV12 extends ApiVersion { val value = "12" }
 case object ApiLatest extends ApiVersion { val value = "latest" }
 
 /*
@@ -59,11 +60,11 @@ final case class RudderUrl(baseUrl: String, version: ApiVersion) {
 
   // endpoint for nodes API - all of them, or just one
   def nodesApi = s"${url}/api/${version.value}/nodes"
-  def nodeApi(id: NodeId): String = nodesApi + "/" + id.value
+  def nodeApi(id: NodeId): String = nodesApi + "/" + id
 
   // node details on Rudder web UI
   def nodeUrl(id: NodeId) =
-    s"""${url}/secure/nodeManager/searchNodes#{"nodeId":"${id.value}"}"""
+    s"""${url}/secure/nodeManager/searchNodes#{"nodeId":"${id}"}"""
 }
 
 final case class TimeoutInterval(seconds: Int) {
@@ -94,28 +95,34 @@ final case class Configuration(
 
 //////////////////////////////// Nodes and Groups ////////////////////////////////
 
-//Rudder node ID, used as key to synchro nodes
-final case class NodeId(value: String)
+//Rudder node ID, used as key to find which nodes belong a given group
+opaque type NodeId = String
+object NodeId {
+  def apply(string: String): NodeId = string
+  given decoder: JsonDecoder[NodeId] = JsonDecoder.string
+  given schema: Schema[NodeId] = Schema.primitive[String]
+}
 
-case class Data(nodes: Seq[Node]) derives JsonDecoder
+case class NodeData(nodes: Chunk[Node]) derives JsonDecoder, Schema
 
 case class Node(
     id: String,
     hostname: String,
     status: String,
     architectureDescription: Option[String],
-    ipAddresses: Seq[String],
+    ipAddresses: Chunk[String],
     lastInventoryDate: Option[String],
     os: Option[Os],
     policyServerId: Option[String],
-    properties: Seq[Property],
+    properties: Chunk[Property],
     ram: Option[Int],
-    accounts: Option[Seq[String]],
+    accounts: Option[Chunk[String]],
     environmentVariables: Option[Map[String, String]],
-    networkInterfaces: Option[Seq[Json]],
-    storage: Option[Seq[Json]],
-    fileSystems: Option[Seq[Json]]
-) derives JsonDecoder
+    networkInterfaces: Option[Chunk[Json]],
+    storage: Option[Chunk[Json]],
+    fileSystems: Option[Chunk[Json]]
+) derives JsonDecoder,
+      Schema
 
 case class Property(name: String, value: String) derives JsonDecoder
 
@@ -130,23 +137,38 @@ case class Os(
 case class RudderNodeResponse(
     action: String,
     result: String,
-    data: Data
-) derives JsonDecoder
+    data: NodeData
+) derives JsonDecoder,
+      Schema
 
 //notice: for nodes, we directly use rundeck
 //NodeEntryImpl, interfacing is much easier.
 
-// definition of a group, with a type
-// for its id
-final case class GroupId(value: String)
+// definition of a group, with a type for its id
+opaque type GroupId = String
+object GroupId {
+  def apply(string: String): GroupId = string
+  given decoder: JsonDecoder[GroupId] = JsonDecoder.string
+  given schema: Schema[GroupId] = Schema.primitive[String]
+}
+
+case class RudderGroupResponse(
+    action: String,
+    result: String,
+    data: GroupData
+) derives JsonDecoder,
+      Schema
+
+case class GroupData(groups: Chunk[Group]) derives JsonDecoder, Schema
 
 final case class Group(
     id: GroupId,
-    name: String,
+    displayName: String,
     nodeIds: Set[NodeId],
-    enable: Boolean,
+    enabled: Boolean,
     dynamic: Boolean
-)
+) derives JsonDecoder,
+      Schema
 
 //////////////////////////////// Error container ////////////////////////////////
 

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -19,11 +19,13 @@ package com.normation.rundeck.plugin.resources.rudder
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import org.slf4j.LoggerFactory
 import zio.Chunk
+import zio.Task
 import zio.ZIO
 import zio.http.*
 import zio.http.Method.GET
-import zio.json.DecoderOps
 import zio.json.ast.Json
+import zio.schema.*
+import zio.schema.codec.JsonCodec.schemaBasedBinaryCodec
 
 /**
  * This file manages the REST query logic. This is where queries to the Rudder
@@ -83,37 +85,29 @@ object RudderAPIQuery {
           )
         )
 
-      body <- response.status match
-        case success: Status.Success =>
-          response.body.asString.orDie
-        case error: Status.Error     =>
-          ErrorMsg(s"Error ${error.code} : ${error.reasonPhrase}").fail
-        case status: Status          =>
-          val errMsg =
-            s"Unsupported response status code : ${status.code} ; details : ${status.reasonPhrase}"
-          ErrorMsg(errMsg).fail
-
-      json <- body.fromJson[RudderNodeResponse] match
-        case Left(errMsg)    => ErrorMsg(errMsg).fail
-        case Right(nodeList) => nodeList.data.nodes.succeed
+      body <- response.processApiResponse().toZIO
+      json <- body
+        .to[RudderNodeResponse]
+        .processDecodingError("node")
 
       /* At this point, the result can no longer be an error :
         The Rudder nodes that cannot be imported into Rundeck will produce a warning log.
         All the other viable nodes will be imported as normal.
        */
       map <- ZIO
-        .foldLeft(json)(Map.empty[NodeId, NodeEntryImpl])((map, node) =>
-          extractNode(node, config)
-            .foldZIO(
-              err =>
-                logger
-                  .warn(
-                    s"Error during import of Rudder node with id \'${node.id}\' : ${err.value}"
-                      + "\nThis node will not be imported."
-                  )
-                  .as(map),
-              nodeEntry => (map + ((NodeId(node.id), nodeEntry))).succeed
-            )
+        .foldLeft(json.data.nodes)(Map.empty[NodeId, NodeEntryImpl])(
+          (map, node) =>
+            extractNode(node, config)
+              .foldZIO(
+                err =>
+                  logger
+                    .warn(
+                      s"Error during import of Rudder node with id \'${node.id}\' : ${err.value}"
+                        + "\nThis node will not be imported."
+                    )
+                    .as(map),
+                nodeEntry => (map + ((NodeId(node.id), nodeEntry))).succeed
+              )
         )
     } yield map
 
@@ -280,6 +274,31 @@ object RudderAPIQuery {
     }
   }
 
+  /**
+   * Query for groups
+   */
+  def queryGroups(config: Configuration): ZIO[Client, ErrorMsg, Seq[Group]] = {
+
+    val url = URL.decode(config.url.groupsApi).toOption.get
+    val headers = Headers(("X-API-Token" -> config.apiToken))
+    val request = Request(method = GET, url = url, headers = headers)
+
+    for {
+      response <- ZClient
+        .batched(request)
+        .mapError(ex =>
+          ErrorMsg(
+            s"Error when trying to get group(s) at url ${url.encode}: " + ex.getMessage,
+            Some(ex)
+          )
+        )
+      body <- response.processApiResponse().toZIO
+      groups <- body
+        .to[RudderGroupResponse]
+        .processDecodingError("group")
+    } yield groups.data.groups
+  }
+
   extension (self: Json)
     private def asSimpleField: Either[String, String | Int | Boolean] =
       self
@@ -293,10 +312,33 @@ object RudderAPIQuery {
         fieldName: String
     ): ErrorMsg =
       field match
-        case Some(_) =>
+        case Some(_) => self
+        case None    =>
           ErrorMsg(
             self.value + "\n" + s"Required field \"${fieldName}\" is missing",
             self.exception
           )
-        case None    => self
+
+  extension (self: Response)
+    private def processApiResponse(): Either[ErrorMsg, Body] =
+      self.status match
+        case success: Status.Success => Right(self.body)
+        case error: Status.Error     =>
+          Left(ErrorMsg(s"Error ${error.code} : ${error.reasonPhrase}"))
+        case status: Status          =>
+          val errMsg =
+            s"Unsupported response status code : ${status.code} ; details : ${status.reasonPhrase}"
+          Left(ErrorMsg(errMsg))
+
+  extension [A](self: Task[A])
+    private def processDecodingError(
+        resourceType: String
+    ): ZIO[Any, ErrorMsg, A] =
+      self.mapError(ex =>
+        ErrorMsg(
+          s"Error during Json decoding of ${resourceType} API query response : "
+            + "the response does not have the expected format",
+          Some(ex)
+        )
+      )
 }

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSource.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSource.scala
@@ -133,7 +133,7 @@ class RudderResourceModelSource(val configuration: Configuration)
             this.lastUpdateTime.set(now)
               *> logger.info(
                 s"Successfully imported Rudder node(s) with id(s) : "
-                  + n.keys.map(_.value).mkString(", ")
+                  + n.keys.mkString(", ")
                   + s"\nSuccessfully imported ${n.size} Rudder node(s)."
               )
               *> this.nodes.set(n.toRundeckNodeSet)
@@ -165,14 +165,15 @@ class RudderResourceModelSource(val configuration: Configuration)
     // not sure if it's better to not update at all if I don't get groups (like here)
     // or keep the old groups with new node infos (I think no), or put empty groups (not sure).
     for {
-      groups <- Seq.empty[Group].succeed
-      newNodes <- RudderAPIQuery.queryNodes(config)
+      (groups, newNodes) <-
+        RudderAPIQuery.queryGroups(config)
+          <&> RudderAPIQuery.queryNodes(config)
     } yield {
       import scala.jdk.CollectionConverters._
-      val groupByNode = getGroupForNode(groups)
+      val groupByNode = RudderResourceModelSource.getGroupForNode(groups)
       // add groups
       newNodes.map { case (nodeId, node) =>
-        val groups = groupByNode.getOrElse(nodeId, Seq()).map(_.name)
+        val groups = groupByNode.getOrElse(nodeId, Seq()).map(_.displayName)
         // add groups to both rudder_information and tags.
         val tags = (node.getTags.asScala ++ groups)
         node.setTags(tags.asJava)
@@ -184,7 +185,11 @@ class RudderResourceModelSource(val configuration: Configuration)
       }
     }
 
-  private def getGroupForNode(
+}
+
+object RudderResourceModelSource {
+
+  def getGroupForNode(
       groups: Seq[Group]
   ): Map[NodeId, Seq[Group]] = {
     // group groups by nodes id.
@@ -192,5 +197,4 @@ class RudderResourceModelSource(val configuration: Configuration)
       groups.flatMap(g => g.nodeIds.map(n => (n, g))).groupBy(_._1)
     groupByNodeId.view.mapValues(_.map(_._2)).toMap
   }
-
 }

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSourceFactory.scala
@@ -142,10 +142,10 @@ object RudderResourceModelSourceFactory {
       PropertyUtil.select(
         API_VERSION,
         "API version",
-        "The API version to use for rundeck. You should use 'latest' appart for compat with older Rudder up to 7.x where version should be '12'",
+        "The API version to use for rundeck. You should use 'latest'",
         true,
         "latest",
-        Seq("latest", "12").asJava
+        Seq("latest").asJava
       )
     )
     .property(
@@ -259,12 +259,11 @@ object RudderResourceModelSourceFactory {
       apiVersion <- getProp(API_VERSION).fold(
         Left(_),
         {
-          case "12"      => Right(ApiV12)
           case "latest"  => Right(ApiLatest)
           case x: String =>
             Left(
               ErrorMsg(
-                s"The API version '${x}' is not authorized, only accepting '12' or 'latest'"
+                s"API version '${x}' is not authorized, only accepting 'latest'"
               )
             )
         }

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/package.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/package.scala
@@ -28,6 +28,12 @@ package object rudder {
     def succeed: UIO[A] =
       ZIO.succeed(self)
 
+  extension [A](self: Either[ErrorMsg, A])
+    def toZIO: ZIO[Any, ErrorMsg, A] =
+      self match
+        case Left(err)    => err.fail
+        case Right(value) => value.succeed
+
   /**
    * Just a shorthand for our "that method can fail, so Either it returns an
    * error, or the actual type you were looking for" type.

--- a/src/test/scala/com/normation/rundeck/plugin/resources/rudder/BuildRundeckNodeTest.scala
+++ b/src/test/scala/com/normation/rundeck/plugin/resources/rudder/BuildRundeckNodeTest.scala
@@ -18,6 +18,8 @@ package com.normation.rundeck.plugin.resources.rudder
 
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import org.junit.runner.RunWith
+import zio.Chunk
+import zio.Exit
 import zio.Scope
 import zio.test.*
 import zio.test.Assertion.*
@@ -47,7 +49,7 @@ class BuildRundeckNodeTest extends ZIOSpecDefault {
           ),
           architectureDescription = Some("x86_64"),
           ram = Some(2062548992),
-          ipAddresses = List(
+          ipAddresses = Chunk(
             "0:0:0:0:0:0:0:1",
             "127.0.0.1",
             "192.168.4.2",
@@ -55,7 +57,7 @@ class BuildRundeckNodeTest extends ZIOSpecDefault {
           ),
           lastInventoryDate = Some("2025-08-08T05:55:12Z"),
           policyServerId = Some("root"),
-          properties = List(),
+          properties = Chunk.empty,
           environmentVariables = None,
           accounts = None,
           networkInterfaces = None,
@@ -107,6 +109,127 @@ class BuildRundeckNodeTest extends ZIOSpecDefault {
 
         assertZIO(converted.map(_.getAttributes))(
           equalTo(expected.getAttributes)
+        )
+      },
+      test(
+        "a Rundeck node entry should not be extracted successfully " +
+          "from a valid Rudder node that is missing attributes that are required in Rundeck"
+      ) {
+        val rudderNode = Node(
+          id = "root",
+          hostname = "server.rudder.local",
+          status = "accepted",
+          os = None,
+          architectureDescription = None,
+          ram = Some(2062548992),
+          ipAddresses = Chunk(
+            "0:0:0:0:0:0:0:1",
+            "127.0.0.1",
+            "192.168.4.2",
+            "10.0.2.15"
+          ),
+          lastInventoryDate = None,
+          policyServerId = Some("policyServerId"),
+          properties = Chunk.empty,
+          environmentVariables = None,
+          accounts = None,
+          networkInterfaces = None,
+          storage = None,
+          fileSystems = None
+        )
+
+        val mockConfig = Configuration(
+          url = RudderUrl("http://127.0.0.1:8080/rudder", ApiLatest),
+          apiToken = "apiToken",
+          apiTimeout = TimeoutInterval(0),
+          checkCertificate = false,
+          refreshInterval = TimeoutInterval(0),
+          sshDefaultPort = 8080,
+          envVarSSLPort = None,
+          rundeckDefaultUser = "rundeck",
+          envVarRundeckUser = None
+        )
+        val converted = RudderAPIQuery.extractNode(rudderNode, mockConfig).exit
+        val errorMsg =
+          "Rudder node with id 'root' is missing one or more required fields : \n" +
+            "Required field \"os\" is missing\n" +
+            "Required field \"architectureDescription\" is missing\n" +
+            "Required field \"lastInventoryDate\" is missing"
+
+        assertZIO(converted)(equalTo(Exit.fail(ErrorMsg(errorMsg, None))))
+      },
+      test(
+        "a Rudder node that is imported into Rundeck should belong to the expected Rudder groups"
+      ) {
+
+        val groups = Seq(
+          Group(
+            id = GroupId("my-group"),
+            displayName = "my-group",
+            nodeIds = Set(NodeId("root")),
+            enabled = true,
+            dynamic = true
+          ),
+          Group(
+            id = GroupId("other-group"),
+            displayName = "other-group",
+            nodeIds = Set(NodeId("A")),
+            enabled = true,
+            dynamic = true
+          ),
+          Group(
+            id = GroupId("yet-another-group"),
+            displayName = "yet-another-group",
+            nodeIds = Set(NodeId("root"), NodeId("A")),
+            enabled = true,
+            dynamic = false
+          ),
+          Group(
+            id = GroupId("all-nodes-with-cfengine-agent"),
+            displayName = "All Linux Nodes",
+            nodeIds = Set(
+              NodeId("root"),
+              NodeId("B"),
+              NodeId("A")
+            ),
+            enabled = true,
+            dynamic = true
+          ),
+          Group(
+            id = GroupId("hasPolicyServer-root"),
+            displayName = "All Linux Nodes managed by root policy server",
+            nodeIds = Set(NodeId("root")),
+            enabled = true,
+            dynamic = true
+          )
+        )
+
+        val groupsForNode =
+          RudderResourceModelSource
+            .getGroupForNode(groups)
+            .view
+            .mapValues(_.map(_.id))
+            .toMap
+
+        assert(groupsForNode)(
+          equalTo(
+            Map(
+              NodeId("root") -> Seq(
+                GroupId("my-group"),
+                GroupId("yet-another-group"),
+                GroupId("all-nodes-with-cfengine-agent"),
+                GroupId("hasPolicyServer-root")
+              ),
+              NodeId("A") -> Seq(
+                GroupId("other-group"),
+                GroupId("yet-another-group"),
+                GroupId("all-nodes-with-cfengine-agent")
+              ),
+              NodeId("B") -> Seq(
+                GroupId("all-nodes-with-cfengine-agent")
+              )
+            )
+          )
         )
       }
     )

--- a/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQueryIT.scala
+++ b/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQueryIT.scala
@@ -37,6 +37,9 @@ object RudderAPIQueryIT extends ZIOAppDefault {
       _ <- RudderAPIQuery
         .queryNodes(config)
         .debug
+      groups <- RudderAPIQuery
+        .queryGroups(config)
+        .debug
     } yield ()
 
   override def run: ZIO[Any & ZIOAppArgs & Scope, Any, Any] =

--- a/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderCodecTest.scala
+++ b/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderCodecTest.scala
@@ -28,213 +28,476 @@ class RudderCodecTest extends ZIOSpecDefault {
 
   override def spec: Spec[TestEnvironment & Scope, Any] = {
     suite("json codec test")(
-      test("decoding should succeed when all required fields are present") {
+      suite("nodes")(
+        test("decoding should succeed when all required fields are present") {
 
-        val json =
-          """{
-          |  "action": "listAcceptedNodes",
-          |  "result": "success",
-          |  "data": {
-          |    "nodes": [
-          |      {
-          |        "id": "root",
-          |        "hostname": "server.rudder.local",
-          |        "status": "accepted",
-          |        "state": "enabled",
-          |        "os": {
-          |          "type": "Linux",
-          |          "name": "Debian",
-          |          "version": "12",
-          |          "fullName": "Debian GNU/Linux 12 (bookworm)",
-          |          "kernelVersion": "6.1.0-37-amd64"
-          |        },
-          |        "architectureDescription": "x86_64",
-          |        "ram": 2062548992,
-          |        "machine": {
-          |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
-          |          "type": "Virtual",
-          |          "provider": "vbox",
-          |          "manufacturer": "innotek GmbH",
-          |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
-          |        },
-          |        "ipAddresses": [
-          |          "0:0:0:0:0:0:0:1",
-          |          "127.0.0.1",
-          |          "fe80:0:0:0:a00:27ff:fec1:798b",
-          |          "192.168.4.2",
-          |          "fe80:0:0:0:a00:27ff:fe8d:c04d",
-          |          "10.0.2.15"
-          |        ],
-          |        "description": "",
-          |        "acceptanceDate": "2025-04-02T12:46:58Z",
-          |        "lastInventoryDate": "2025-08-08T05:55:12Z",
-          |        "policyServerId": "root",
-          |        "managementTechnology": [
-          |          {
-          |            "name": "Rudder",
-          |            "version": "8.2.5-debian12",
-          |            "capabilities": [
-          |              "acl",
-          |              "cfengine",
-          |              "curl",
-          |              "http_reporting",
-          |              "jq",
-          |              "xml",
-          |              "yaml"
-          |            ],
-          |            "nodeKind": "root"
-          |          }
-          |        ],
-          |        "properties": [
-          |          {
-          |            "name": "prop",
-          |            "value": "prop_value"
-          |          }
-          |        ],
-          |        "policyMode": "default",
-          |        "timezone": {
-          |          "name": "UTC",
-          |          "offset": "+0000"
-          |        },
-          |        "environmentVariables": {
-          |          "envKey": "envVal"
-          |        }
-          |      }
-          |    ]
-          |  }
-          |}
-          |""".stripMargin
+          val json =
+            """{
+              |  "action": "listAcceptedNodes",
+              |  "result": "success",
+              |  "data": {
+              |    "nodes": [
+              |      {
+              |        "id": "root",
+              |        "hostname": "server.rudder.local",
+              |        "status": "accepted",
+              |        "state": "enabled",
+              |        "os": {
+              |          "type": "Linux",
+              |          "name": "Debian",
+              |          "version": "12",
+              |          "fullName": "Debian GNU/Linux 12 (bookworm)",
+              |          "kernelVersion": "6.1.0-37-amd64"
+              |        },
+              |        "architectureDescription": "x86_64",
+              |        "ram": 2062548992,
+              |        "machine": {
+              |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
+              |          "type": "Virtual",
+              |          "provider": "vbox",
+              |          "manufacturer": "innotek GmbH",
+              |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
+              |        },
+              |        "ipAddresses": [
+              |          "0:0:0:0:0:0:0:1",
+              |          "127.0.0.1",
+              |          "fe80:0:0:0:a00:27ff:fec1:798b",
+              |          "192.168.4.2",
+              |          "fe80:0:0:0:a00:27ff:fe8d:c04d",
+              |          "10.0.2.15"
+              |        ],
+              |        "description": "",
+              |        "acceptanceDate": "2025-04-02T12:46:58Z",
+              |        "lastInventoryDate": "2025-08-08T05:55:12Z",
+              |        "policyServerId": "root",
+              |        "managementTechnology": [
+              |          {
+              |            "name": "Rudder",
+              |            "version": "8.2.5-debian12",
+              |            "capabilities": [
+              |              "acl",
+              |              "cfengine",
+              |              "curl",
+              |              "http_reporting",
+              |              "jq",
+              |              "xml",
+              |              "yaml"
+              |            ],
+              |            "nodeKind": "root"
+              |          }
+              |        ],
+              |        "properties": [
+              |          {
+              |            "name": "prop",
+              |            "value": "prop_value"
+              |          }
+              |        ],
+              |        "policyMode": "default",
+              |        "timezone": {
+              |          "name": "UTC",
+              |          "offset": "+0000"
+              |        },
+              |        "environmentVariables": {
+              |          "envKey": "envVal"
+              |        }
+              |      }
+              |    ]
+              |  }
+              |}
+              |""".stripMargin
 
-        val decoded = json.fromJson[RudderNodeResponse]
+          val decoded = json.fromJson[RudderNodeResponse]
 
-        val expected = RudderNodeResponse(
-          action = "listAcceptedNodes",
-          result = "success",
-          data = Data(
-            List(
-              Node(
-                id = "root",
-                hostname = "server.rudder.local",
-                status = "accepted",
-                os = Some(
-                  Os(
-                    `type` = "Linux",
-                    name = "Debian",
-                    version = "12",
-                    fullName = "Debian GNU/Linux 12 (bookworm)",
-                    kernelVersion = "6.1.0-37-amd64"
-                  )
-                ),
-                architectureDescription = Some("x86_64"),
-                ram = Some(2062548992),
-                ipAddresses = List(
-                  "0:0:0:0:0:0:0:1",
-                  "127.0.0.1",
-                  "fe80:0:0:0:a00:27ff:fec1:798b",
-                  "192.168.4.2",
-                  "fe80:0:0:0:a00:27ff:fe8d:c04d",
-                  "10.0.2.15"
-                ),
-                lastInventoryDate = Some("2025-08-08T05:55:12Z"),
-                policyServerId = Some("root"),
-                properties = List(Property("prop", "prop_value")),
-                environmentVariables = Some(Map.apply(("envKey", "envVal"))),
-                accounts = None,
-                networkInterfaces = None,
-                storage = None,
-                fileSystems = None
+          val expected = RudderNodeResponse(
+            action = "listAcceptedNodes",
+            result = "success",
+            data = NodeData(
+              Chunk(
+                Node(
+                  id = "root",
+                  hostname = "server.rudder.local",
+                  status = "accepted",
+                  os = Some(
+                    Os(
+                      `type` = "Linux",
+                      name = "Debian",
+                      version = "12",
+                      fullName = "Debian GNU/Linux 12 (bookworm)",
+                      kernelVersion = "6.1.0-37-amd64"
+                    )
+                  ),
+                  architectureDescription = Some("x86_64"),
+                  ram = Some(2062548992),
+                  ipAddresses = Chunk(
+                    "0:0:0:0:0:0:0:1",
+                    "127.0.0.1",
+                    "fe80:0:0:0:a00:27ff:fec1:798b",
+                    "192.168.4.2",
+                    "fe80:0:0:0:a00:27ff:fe8d:c04d",
+                    "10.0.2.15"
+                  ),
+                  lastInventoryDate = Some("2025-08-08T05:55:12Z"),
+                  policyServerId = Some("root"),
+                  properties = Chunk(Property("prop", "prop_value")),
+                  environmentVariables = Some(Map.apply(("envKey", "envVal"))),
+                  accounts = None,
+                  networkInterfaces = None,
+                  storage = None,
+                  fileSystems = None
+                )
               )
             )
           )
-        )
 
-        assert(decoded)(isRight(equalTo(expected)))
+          assert(decoded)(isRight(equalTo(expected)))
 
-      },
-      test("decoding should fail when a required field is missing") {
-        val json =
-          """{
-          |  "action": "listAcceptedNodes",
-          |  "result": "success",
-          |  "data": {
-          |    "nodes": [
-          |      {
-          |        "id": "root",
-          |        "hostname": "server.rudder.local",
-          |        "status": "accepted",
-          |        "state": "enabled",
-          |        "architectureDescription": "x86_64",
-          |        "ram": 2062548992,
-          |        "machine": {
-          |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
-          |          "type": "Virtual",
-          |          "provider": "vbox",
-          |          "manufacturer": "innotek GmbH",
-          |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
-          |        },
-          |        "ipAddresses": [
-          |          "0:0:0:0:0:0:0:1",
-          |          "127.0.0.1",
-          |          "192.168.4.2",
-          |          "10.0.2.15"
-          |        ],
-          |        "description": "",
-          |        "acceptanceDate": "2025-04-02T12:46:58Z",
-          |        "lastInventoryDate": "2025-08-08T05:55:12Z",
-          |        "policyServerId": "root"
-          |      }
-          |    ]
-          |  }
-          |}
-          |""".stripMargin
+        },
+        test("decoding should fail when a required field is missing") {
+          val json =
+            """{
+              |  "action": "listAcceptedNodes",
+              |  "result": "success",
+              |  "data": {
+              |    "nodes": [
+              |      {
+              |        "id": "root",
+              |        "hostname": "server.rudder.local",
+              |        "status": "accepted",
+              |        "state": "enabled",
+              |        "architectureDescription": "x86_64",
+              |        "ram": 2062548992,
+              |        "machine": {
+              |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
+              |          "type": "Virtual",
+              |          "provider": "vbox",
+              |          "manufacturer": "innotek GmbH",
+              |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
+              |        },
+              |        "ipAddresses": [
+              |          "0:0:0:0:0:0:0:1",
+              |          "127.0.0.1",
+              |          "192.168.4.2",
+              |          "10.0.2.15"
+              |        ],
+              |        "description": "",
+              |        "acceptanceDate": "2025-04-02T12:46:58Z",
+              |        "lastInventoryDate": "2025-08-08T05:55:12Z",
+              |        "policyServerId": "root"
+              |      }
+              |    ]
+              |  }
+              |}
+              |""".stripMargin
 
-        val decoded = json.fromJson[RudderNodeResponse]
-        val errMsg = ".data.nodes[0].properties(missing)"
+          val decoded = json.fromJson[RudderNodeResponse]
+          val errMsg = ".data.nodes[0].properties(missing)"
 
-        assert(decoded)(isLeft(equalTo(errMsg)))
+          assert(decoded)(isLeft(equalTo(errMsg)))
 
-      },
-      test("decoding should fail when several required fields are missing") {
-        val json =
-          """{
-            |  "action": "listAcceptedNodes",
-            |  "result": "success",
-            |  "data": {
-            |    "nodes": [
-            |      {
-            |        "id": "root",
-            |        "hostname": "server.rudder.local",
-            |        "ram": 2062548992,
-            |        "machine": {
-            |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
-            |          "type": "Virtual",
-            |          "provider": "vbox",
-            |          "manufacturer": "innotek GmbH",
-            |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
-            |        },
-            |        "os": {
-            |          "type": "Linux",
-            |          "name": "Debian",
-            |          "version": "12",
-            |          "fullName": "Debian GNU/Linux 12 (bookworm)",
-            |          "kernelVersion": "6.1.0-37-amd64"
-            |        },
-            |        "description": "",
-            |        "acceptanceDate": "2025-04-02T12:46:58Z",
-            |        "policyServerId": "root",
-            |        "properties": []
-            |      }
-            |    ]
-            |  }
-            |}
-            |""".stripMargin
+        },
+        test("decoding should fail when several required fields are missing") {
+          val json =
+            """{
+              |  "action": "listAcceptedNodes",
+              |  "result": "success",
+              |  "data": {
+              |    "nodes": [
+              |      {
+              |        "id": "root",
+              |        "hostname": "server.rudder.local",
+              |        "ram": 2062548992,
+              |        "machine": {
+              |          "id": "63a9f0ea-7bb9-8050-796b-649e85481845",
+              |          "type": "Virtual",
+              |          "provider": "vbox",
+              |          "manufacturer": "innotek GmbH",
+              |          "serialNumber": "87932606-339f-4e0e-a343-f5e3ece18c55"
+              |        },
+              |        "os": {
+              |          "type": "Linux",
+              |          "name": "Debian",
+              |          "version": "12",
+              |          "fullName": "Debian GNU/Linux 12 (bookworm)",
+              |          "kernelVersion": "6.1.0-37-amd64"
+              |        },
+              |        "description": "",
+              |        "acceptanceDate": "2025-04-02T12:46:58Z",
+              |        "policyServerId": "root",
+              |        "properties": []
+              |      }
+              |    ]
+              |  }
+              |}
+              |""".stripMargin
 
-        val decoded = json.fromJson[RudderNodeResponse]
-        val errMsg = ".data.nodes[0].status(missing)"
+          val decoded = json.fromJson[RudderNodeResponse]
+          val errMsg = ".data.nodes[0].status(missing)"
 
-        assert(decoded)(isLeft(equalTo(errMsg)))
+          assert(decoded)(isLeft(equalTo(errMsg)))
 
-      }
+        }
+      ),
+      suite("groups")(
+        test("decoding should succeed when all required fields are present") {
+
+          val json =
+            """{
+              |  "action": "listGroups",
+              |  "result": "success",
+              |  "data": {
+              |    "groups": [
+              |      {
+              |        "id": "my-group",
+              |        "displayName": "my-group",
+              |        "description": "",
+              |        "category": "GroupRoot",
+              |        "nodeIds": [
+              |          "root"
+              |        ],
+              |        "dynamic": false,
+              |        "enabled": true,
+              |        "groupClass": [
+              |          "group_my_group",
+              |          "group_test_group10"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:my-group",
+              |        "system": false
+              |      },
+              |      {
+              |        "id": "other-group",
+              |        "displayName": "other-group",
+              |        "description": "",
+              |        "category": "GroupRoot",
+              |        "query": {
+              |          "select": "node",
+              |          "composition": "and",
+              |          "where": []
+              |        },
+              |        "nodeIds": [
+              |          "A"
+              |        ],
+              |        "dynamic": true,
+              |        "enabled": true,
+              |        "groupClass": [
+              |          "group_other_group",
+              |          "group_test_group"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:other-group",
+              |        "system": false
+              |      },
+              |      {
+              |        "id": "yet-another-group",
+              |        "displayName": "yet-another-group",
+              |        "description": "",
+              |        "category": "GroupRoot",
+              |        "nodeIds": [
+              |          "root",
+              |          "A"
+              |        ],
+              |        "dynamic": true,
+              |        "enabled": false,
+              |        "groupClass": [
+              |          "group_yet_another_group",
+              |          "group_test_group6"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:yet-another-group",
+              |        "system": false
+              |      },
+              |      {
+              |        "id": "all-nodes-with-cfengine-agent",
+              |        "displayName": "All Linux Nodes",
+              |        "description": "All Linux Nodes known by Rudder",
+              |        "category": "SystemGroups",
+              |        "query": {
+              |          "select": "nodeAndPolicyServer",
+              |          "composition": "and",
+              |          "where": [
+              |            {
+              |              "objectType": "node",
+              |              "attribute": "agentName",
+              |              "comparator": "eq",
+              |              "value": "cfengine"
+              |            }
+              |          ]
+              |        },
+              |        "nodeIds": [
+              |          "root",
+              |          "A",
+              |          "B"
+              |        ],
+              |        "dynamic": true,
+              |        "enabled": true,
+              |        "groupClass": [
+              |          "group_all_linux_nodes",
+              |          "group_all_nodes_with_cfengine_agent"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:all-nodes-with-cfengine-agent",
+              |        "system": true
+              |      },
+              |      {
+              |        "id": "hasPolicyServer-root",
+              |        "displayName": "All Linux Nodes managed by root policy server",
+              |        "description": "All Linux Nodes known by Rudder directly connected to the root server. This group exists only as internal purpose and should not be used to configure nodes.",
+              |        "category": "SystemGroups",
+              |        "query": {
+              |          "select": "nodeAndPolicyServer",
+              |          "composition": "and",
+              |          "where": [
+              |            {
+              |              "objectType": "node",
+              |              "attribute": "policyServerId",
+              |              "comparator": "eq",
+              |              "value": "root"
+              |            },
+              |            {
+              |              "objectType": "node",
+              |              "attribute": "agentName",
+              |              "comparator": "eq",
+              |              "value": "cfengine"
+              |            }
+              |          ]
+              |        },
+              |        "nodeIds": [
+              |          "root"
+              |        ],
+              |        "dynamic": true,
+              |        "enabled": true,
+              |        "groupClass": [
+              |          "group_all_linux_nodes_managed_by_root_policy_server",
+              |          "group_haspolicyserver_root"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:hasPolicyServer-root",
+              |        "system": true
+              |      }
+              |    ]
+              |  }
+              |}
+              |""".stripMargin
+
+          val decoded = json.fromJson[RudderGroupResponse]
+
+          val expected = RudderGroupResponse(
+            action = "listGroups",
+            result = "success",
+            data = GroupData(
+              Chunk(
+                Group(
+                  id = GroupId("my-group"),
+                  displayName = "my-group",
+                  nodeIds = Set(NodeId("root")),
+                  enabled = true,
+                  dynamic = false
+                ),
+                Group(
+                  id = GroupId("other-group"),
+                  displayName = "other-group",
+                  nodeIds = Set(NodeId("A")),
+                  enabled = true,
+                  dynamic = true
+                ),
+                Group(
+                  id = GroupId("yet-another-group"),
+                  displayName = "yet-another-group",
+                  nodeIds = Set(NodeId("root"), NodeId("A")),
+                  enabled = false,
+                  dynamic = true
+                ),
+                Group(
+                  id = GroupId("all-nodes-with-cfengine-agent"),
+                  displayName = "All Linux Nodes",
+                  nodeIds = Set(
+                    NodeId("root"),
+                    NodeId("A"),
+                    NodeId("B")
+                  ),
+                  enabled = true,
+                  dynamic = true
+                ),
+                Group(
+                  id = GroupId("hasPolicyServer-root"),
+                  displayName = "All Linux Nodes managed by root policy server",
+                  nodeIds = Set(NodeId("root")),
+                  enabled = true,
+                  dynamic = true
+                )
+              )
+            )
+          )
+
+          assert(decoded)(isRight(equalTo(expected)))
+
+        },
+        test("decoding should succeed if there are no groups") {
+
+          val json =
+            """{
+              |  "action": "listGroups",
+              |  "result": "success",
+              |  "data": {
+              |    "groups": []
+              |  }
+              |}
+              |""".stripMargin
+
+          val decoded = json.fromJson[RudderGroupResponse]
+          val expected =
+            RudderGroupResponse("listGroups", "success", GroupData(Chunk.empty))
+
+          assert(decoded)(isRight(equalTo(expected)))
+
+        },
+        test("decoding should fail when a required field is missing") {
+
+          val json =
+            """{
+              |  "action": "listGroups",
+              |  "result": "success",
+              |  "data": {
+              |    "groups": [
+              |      {
+              |        "id": "bcd19231-0899-42c3-8e92-41c3c0a6fd2f",
+              |        "displayName": "test-group3",
+              |        "description": "",
+              |        "category": "GroupRoot",
+              |        "query": {
+              |          "select": "nodeAndPolicyServer",
+              |          "composition": "and",
+              |          "where": [
+              |            {
+              |              "objectType": "node",
+              |              "attribute": "OS",
+              |              "comparator": "eq",
+              |              "value": "Linux"
+              |            }
+              |          ]
+              |        },
+              |        "dynamic": true,
+              |        "enabled": true,
+              |        "groupClass": [
+              |          "group_bcd19231_0899_42c3_8e92_41c3c0a6fd2f",
+              |          "group_test_group3"
+              |        ],
+              |        "properties": [],
+              |        "target": "group:bcd19231-0899-42c3-8e92-41c3c0a6fd2f",
+              |        "system": false
+              |      }
+              |    ]
+              |  }
+              |}
+              |""".stripMargin
+
+          val decoded = json.fromJson[RudderGroupResponse]
+          val errMsg = ".data.groups[0].nodeIds(missing)"
+
+          assert(decoded)(isLeft(equalTo(errMsg)))
+
+        }
+      )
     )
   }
 }


### PR DESCRIPTION
#16 

This PR aims to implement the import of Rudder groups as tags for each Rudder node. This feature makes the plugin equivalent to the previous version in terms of features.

A few test cases have been added in order to test:
-  the decoding process of a list of groups from the Rudder API response (see `RudderCodecTest`)
- the function that builds a map that binds each node identifier to the set of the group ids of the groups in which the node belongs (see `BuildRundeckNodeTest`)