### PR TITLE
Fixes #22 : Replace ZIO-Http with sttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
               <Rundeck-Plugin-File-Version>0.1-SNAPSHOT</Rundeck-Plugin-File-Version>
               <Rundeck-Plugin-Archive>true</Rundeck-Plugin-Archive>
               <Rundeck-Plugin-Classnames>com.normation.rundeck.plugin.resources.rudder.RudderResourceModelSourceFactory</Rundeck-Plugin-Classnames>
-              <Rundeck-Plugin-Libs>lib/bcpkix-jdk18on lib/bcprov-jdk18on lib/bcutil-jdk18on lib/iron_3 lib/izumi-reflect_3 lib/izumi-reflect-thirdparty-boopickle-shaded_3 lib/magnolia_3 lib/netty-buffer lib/netty-codec-base lib/netty-codec-compression lib/netty-codec-http lib/netty-codec-socks lib/netty-common lib/netty-handler lib/netty-handler-proxy lib/netty-pkitesting lib/netty-resolver lib/netty-transport-classes-epoll lib/netty-transport-classes-kqueue lib/netty-transport lib/netty-transport-native-epoll lib/netty-transport-native-kqueue lib/netty-transport-native-unix-common lib/portable-scala-reflect_2.13 lib/scala3-library_3 lib/scala-collection-compat_3 lib/scala-library lib/unroll-annotation_3 lib/zio_3 lib/zio-config_3 lib/zio-constraintless_3 lib/zio-http_3 lib/zio-internal-macros_3 lib/zio-json_3 lib/zio-prelude_3 lib/zio-prelude-macros_3 lib/zio-schema_3 lib/zio-schema-derivation_3 lib/zio-schema-json_3 lib/zio-schema-macros_3 lib/zio-schema-protobuf_3 lib/zio-stacktracer_3 lib/zio-streams_3 lib/zio-test_3.jar lib/slf4j-api lib/slf4j-simple</Rundeck-Plugin-Libs>
+              <Rundeck-Plugin-Libs>lib/com.softwaremill.magnolia1_3:magnolia_3 lib/com.softwaremill.sttp.client4:core_3 lib/com.softwaremill.sttp.client4:json-common_3 lib/com.softwaremill.sttp.client4:zio_3 lib/com.softwaremill.sttp.client4:zio-json_3 lib/com.softwaremill.sttp.client4:slf4j-backend_3 lib/com.softwaremill.sttp.model:core_3 lib/com.softwaremill.sttp.shared:core_3 lib/com.softwaremill.sttp.shared:ws_3 lib/com.softwaremill.sttp.shared:zio_3 lib/dev.zio:izumi-reflect_3 lib/dev.zio:izumi-reflect-thirdparty-boopickle-shaded_3 lib/dev.zio:zio_3 lib/dev.zio:zio-config_3 lib/dev.zio:zio-internal-macros_3 lib/dev.zio:zio-interop-reactivestreams_3 lib/dev.zio:zio-json_3 lib/dev.zio:zio-stacktracer_3 lib/dev.zio:zio-streams_3 lib/io.github.iltotore:iron_3 lib/org.reactivestreams:reactive-streams lib/org.scala-lang.modules:scala-collection-compat_3 lib/org.scala-lang:scala3-library_3 lib/org.scala-lang:scala-library lib/org.slf4j:slf4j-api lib/org.slf4j:slf4j-simple</Rundeck-Plugin-Libs>
             </manifestEntries>
           </archive>
         </configuration>
@@ -105,7 +105,6 @@
             </includes>
             <excludes>
             </excludes>
-
             <scalafmt>
               <version>3.9.9</version>
               <file>.scalafmt.conf</file>
@@ -150,17 +149,35 @@
       <groupId>dev.zio</groupId>
       <artifactId>zio_3</artifactId>
       <version>${zio.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>dev.zio</groupId>
-      <artifactId>zio-http_3</artifactId>
-      <version>3.3.3</version>
+      <groupId>com.softwaremill.sttp.client4</groupId>
+      <artifactId>zio_3</artifactId>
+      <version>4.0.9</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.softwaremill.sttp.client4</groupId>
+      <artifactId>zio-json_3</artifactId>
+      <version>4.0.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>2.0.17</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.softwaremill.sttp.client4</groupId>
+      <artifactId>slf4j-backend_3</artifactId>
+      <version>4.0.10</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/assembly/jar.xml
+++ b/src/main/assembly/jar.xml
@@ -43,7 +43,7 @@
             <unpack>false</unpack>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <!-- We want a simpler output format with just the artificat name, on version, no jar -->
-            <outputFileNameMapping>${artifact.artifactId}<!-- .${artifact.extension} --></outputFileNameMapping>
+            <outputFileNameMapping>${artifact.groupId}:${artifact.artifactId}<!-- .${artifact.extension} --></outputFileNameMapping>
             <excludes/>
             <scope>runtime</scope>
         </dependencySet>

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/DataModel.scala
@@ -19,9 +19,6 @@ package com.normation.rundeck.plugin.resources.rudder
 import zio.*
 import zio.json.*
 import zio.json.ast.Json
-import zio.schema.DeriveSchema
-import zio.schema.Schema
-import zio.schema.derived
 
 /**
  * This file contains data structure definition for our model.
@@ -37,10 +34,7 @@ import zio.schema.derived
 sealed trait ApiVersion { def value: String }
 
 /*
- * If you use latest with Rudder 4.x, you
- * will have a clear error, nothing works => change version.
- * Auto API upgrade are not relevant, since the plugin won't
- * take advantage of them without an update.
+  Supported API versions
  */
 case object ApiLatest extends ApiVersion { val value = "latest" }
 
@@ -64,7 +58,7 @@ final case class RudderUrl(baseUrl: String, version: ApiVersion) {
 
   // node details on Rudder web UI
   def nodeUrl(id: NodeId) =
-    s"""${url}/secure/nodeManager/searchNodes#{"nodeId":"${id}"}"""
+    s"""${url}/secure/nodeManager/node/${id}"""
 }
 
 final case class TimeoutInterval(seconds: Int) {
@@ -100,10 +94,9 @@ opaque type NodeId = String
 object NodeId {
   def apply(string: String): NodeId = string
   given decoder: JsonDecoder[NodeId] = JsonDecoder.string
-  given schema: Schema[NodeId] = Schema.primitive[String]
 }
 
-case class NodeData(nodes: Chunk[Node]) derives JsonDecoder, Schema
+case class NodeData(nodes: Chunk[Node]) derives JsonDecoder
 
 case class Node(
     id: String,
@@ -121,8 +114,7 @@ case class Node(
     networkInterfaces: Option[Chunk[Json]],
     storage: Option[Chunk[Json]],
     fileSystems: Option[Chunk[Json]]
-) derives JsonDecoder,
-      Schema
+) derives JsonDecoder
 
 case class Property(name: String, value: String) derives JsonDecoder
 
@@ -138,28 +130,22 @@ case class RudderNodeResponse(
     action: String,
     result: String,
     data: NodeData
-) derives JsonDecoder,
-      Schema
-
-//notice: for nodes, we directly use rundeck
-//NodeEntryImpl, interfacing is much easier.
+) derives JsonDecoder
 
 // definition of a group, with a type for its id
 opaque type GroupId = String
 object GroupId {
   def apply(string: String): GroupId = string
   given decoder: JsonDecoder[GroupId] = JsonDecoder.string
-  given schema: Schema[GroupId] = Schema.primitive[String]
 }
 
 case class RudderGroupResponse(
     action: String,
     result: String,
     data: GroupData
-) derives JsonDecoder,
-      Schema
+) derives JsonDecoder
 
-case class GroupData(groups: Chunk[Group]) derives JsonDecoder, Schema
+case class GroupData(groups: Chunk[Group]) derives JsonDecoder
 
 final case class Group(
     id: GroupId,
@@ -167,8 +153,7 @@ final case class Group(
     nodeIds: Set[NodeId],
     enabled: Boolean,
     dynamic: Boolean
-) derives JsonDecoder,
-      Schema
+) derives JsonDecoder
 
 //////////////////////////////// Error container ////////////////////////////////
 

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQuery.scala
@@ -18,14 +18,17 @@ package com.normation.rundeck.plugin.resources.rudder
 
 import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import org.slf4j.LoggerFactory
+import scala.concurrent.duration
+import scala.concurrent.duration.Duration
+import sttp.client4.*
+import sttp.client4.httpclient.zio.SttpClient
+import sttp.client4.httpclient.zio.send
+import sttp.client4.ziojson.*
+import sttp.model.Header
+import sttp.model.QueryParams
 import zio.Chunk
-import zio.Task
 import zio.ZIO
-import zio.http.*
-import zio.http.Method.GET
 import zio.json.ast.Json
-import zio.schema.*
-import zio.schema.codec.JsonCodec.schemaBasedBinaryCodec
 
 /**
  * This file manages the REST query logic. This is where queries to the Rudder
@@ -67,29 +70,21 @@ object RudderAPIQuery {
    */
   def queryNodes(
       config: Configuration
-  ): ZIO[Client, ErrorMsg, Map[NodeId, NodeEntryImpl]] = {
+  ): ZIO[SttpClient, ErrorMsg, Map[NodeId, NodeEntryImpl]] = {
 
-    val queryUrl = config.url.nodesApi
-    val fullUrl =
-      URL.decode(queryUrl + QueryParams(topic -> params).encode).toOption.get
-    val headers = Headers(("X-API-Token" -> config.apiToken))
-    val request = Request(method = GET, url = fullUrl, headers = headers)
+    val request = basicRequest
+      .get(
+        uri"${config.url.nodesApi}"
+          .withParams(QueryParams.fromSeq(Seq((topic, params.mkString(",")))))
+      )
+      .readTimeout(Duration(config.apiTimeout.ms, duration.MILLISECONDS))
+      .headers(Header("X-API-Token", config.apiToken))
+      .contentType("application/json")
+      .response(asJson[RudderNodeResponse])
 
     for {
-      response <- ZClient
-        .batched(request)
-        .mapError(ex =>
-          ErrorMsg(
-            s"Error when trying to get node(s) at url ${fullUrl.encode}: " + ex.getMessage,
-            Some(ex)
-          )
-        )
-
-      body <- response.processApiResponse().toZIO
-      json <- body
-        .to[RudderNodeResponse]
-        .processDecodingError("node")
-
+      response <- request.sendApiRequest("nodes")
+      json <- response.processApiResponse()
       /* At this point, the result can no longer be an error :
         The Rudder nodes that cannot be imported into Rundeck will produce a warning log.
         All the other viable nodes will be imported as normal.
@@ -110,7 +105,6 @@ object RudderAPIQuery {
               )
         )
     } yield map
-
   }
 
   /**
@@ -277,26 +271,21 @@ object RudderAPIQuery {
   /**
    * Query for groups
    */
-  def queryGroups(config: Configuration): ZIO[Client, ErrorMsg, Seq[Group]] = {
+  def queryGroups(
+      config: Configuration
+  ): ZIO[SttpClient, ErrorMsg, Chunk[Group]] = {
 
-    val url = URL.decode(config.url.groupsApi).toOption.get
-    val headers = Headers(("X-API-Token" -> config.apiToken))
-    val request = Request(method = GET, url = url, headers = headers)
+    val request = basicRequest
+      .get(uri"${config.url.groupsApi}")
+      .readTimeout(Duration(config.apiTimeout.ms, duration.MILLISECONDS))
+      .headers(Header("X-API-Token", config.apiToken))
+      .contentType("application/json")
+      .response(asJson[RudderGroupResponse])
 
     for {
-      response <- ZClient
-        .batched(request)
-        .mapError(ex =>
-          ErrorMsg(
-            s"Error when trying to get group(s) at url ${url.encode}: " + ex.getMessage,
-            Some(ex)
-          )
-        )
-      body <- response.processApiResponse().toZIO
-      groups <- body
-        .to[RudderGroupResponse]
-        .processDecodingError("group")
-    } yield groups.data.groups
+      response <- request.sendApiRequest("groups")
+      json <- response.processApiResponse()
+    } yield json.data.groups
   }
 
   extension (self: Json)
@@ -319,26 +308,29 @@ object RudderAPIQuery {
             self.exception
           )
 
-  extension (self: Response)
-    private def processApiResponse(): Either[ErrorMsg, Body] =
-      self.status match
-        case success: Status.Success => Right(self.body)
-        case error: Status.Error     =>
-          Left(ErrorMsg(s"Error ${error.code} : ${error.reasonPhrase}"))
-        case status: Status          =>
-          val errMsg =
-            s"Unsupported response status code : ${status.code} ; details : ${status.reasonPhrase}"
-          Left(ErrorMsg(errMsg))
-
-  extension [A](self: Task[A])
-    private def processDecodingError(
+  extension [A](request: Request[Either[ResponseException[String], A]])
+    private def sendApiRequest(
         resourceType: String
-    ): ZIO[Any, ErrorMsg, A] =
-      self.mapError(ex =>
-        ErrorMsg(
-          s"Error during Json decoding of ${resourceType} API query response : "
-            + "the response does not have the expected format",
-          Some(ex)
+    ): ZIO[SttpClient, ErrorMsg, Response[
+      Either[ResponseException[String], A]
+    ]] =
+      for {
+        response <- send(request).mapError(ex =>
+          ErrorMsg(
+            s"Error in response for Rudder API ${resourceType} query",
+            Some(ex)
+          )
         )
-      )
+      } yield response
+
+  extension [A](response: Response[Either[ResponseException[String], A]])
+    private def processApiResponse(): ZIO[SttpClient, ErrorMsg, A] =
+      for {
+        json <-
+          if (response.isSuccess) {
+            ZIO
+              .fromEither(response.body)
+              .mapError(err => ErrorMsg(err.getMessage))
+          } else ErrorMsg(response.statusText).fail
+      } yield json
 }

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSource.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/RudderResourceModelSource.scala
@@ -22,20 +22,24 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl
 import com.dtolabs.rundeck.core.common.NodeSetImpl
 import com.dtolabs.rundeck.core.resources.ResourceModelSource
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException
+import java.net.Socket
+import java.net.http.HttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedTrustManager
+import javax.net.ssl.X509TrustManager
 import org.slf4j.LoggerFactory
-import zio.Duration
+import sttp.client4.httpclient.zio.HttpClientZioBackend
+import sttp.client4.httpclient.zio.SttpClient
+import sttp.client4.logging.slf4j.Slf4jLoggingBackend
 import zio.Ref
 import zio.UIO
 import zio.Unsafe
 import zio.ZIO
 import zio.ZLayer
-import zio.http.Client
-import zio.http.ClientSSLConfig
-import zio.http.DnsResolver
-import zio.http.ZClient
-import zio.http.ZClient.Config
-import zio.http.netty.NettyConfig
 
 /**
  * This is the entry point for one Rudder provisioning. It is responsible for
@@ -55,18 +59,6 @@ class RudderResourceModelSource(val configuration: Configuration)
   // last time, in ms, that nodes and groups were update (result of System.getCurrentTimeMillis)
   private val lastUpdateTime = Ref.make(0L).unsafeRun
 
-  private val clientConfig = ZClient.Config.default
-    .connectionTimeout(
-      Duration.fromSeconds(configuration.apiTimeout.seconds)
-    )
-    .ssl(
-      if configuration.checkCertificate then ClientSSLConfig.FromJavaxNetSsl()
-      else ClientSSLConfig.Default
-    )
-
-  // client defaults, see https://github.com/zio/zio-http/issues/2403
-  private val nettyConfig = NettyConfig.defaultWithFastShutdown
-
   /**
    * This is the actual, only integration point with Rundeck. The logic is to
    * cache nodes for some time, to avoid too many request to Rudder (especially
@@ -75,13 +67,26 @@ class RudderResourceModelSource(val configuration: Configuration)
   @throws(classOf[ResourceModelSourceException])
   override def getNodes: INodeSet =
 
+    val backend =
+      if (configuration.checkCertificate)
+        HttpClientZioBackend.layer()
+      else {
+        val ssl = SSLContext.getInstance("TLS")
+        val trustManager = RudderResourceModelSource.DangerAcceptInvalidCerts
+        ssl.init(null, Array(trustManager), new SecureRandom)
+
+        val httpClient = HttpClient.newBuilder().sslContext(ssl).build()
+
+        ZLayer.scoped {
+          HttpClientZioBackend
+            .layerUsingClient(httpClient)
+            .build
+            .map(l => Slf4jLoggingBackend(l.get[SttpClient]))
+        }
+      }
+
     updateNodesAndGroups()
-      .provide(
-        ZLayer.succeed(clientConfig),
-        ZLayer.succeed(nettyConfig),
-        Client.live.orDie,
-        DnsResolver.default
-      )
+      .provideLayer(backend.orDie)
       .unsafeRun
 
   extension [A](self: UIO[A])
@@ -101,9 +106,9 @@ class RudderResourceModelSource(val configuration: Configuration)
     }
 
   /**
-   * Update the local node cache is needed
+   * Update the local node cache if needed
    */
-  private def updateNodesAndGroups(): ZIO[Client, Nothing, INodeSet] =
+  private def updateNodesAndGroups(): ZIO[SttpClient, Nothing, INodeSet] =
 
     for {
       now <- ZIO.clockWith(_.currentTime(TimeUnit.MILLISECONDS))
@@ -125,16 +130,12 @@ class RudderResourceModelSource(val configuration: Configuration)
                 logger.error("Root exception was: ", ex)
               },
           n =>
-            // we only update time here, meaning that each time there is an error,
-            // we will try again next time.
-            // that may lead to funny loop when there is always error and user query quickly the
-            // method, but the user would not understand if he repairs an error on Rudder, and
-            // things don't work immediately.
+            // lastUpdateTime is only updated if the nodes were successfully retrieved.
+            // Hence, if an error occurred, the update will be attempted again on the next call.
             this.lastUpdateTime.set(now)
               *> logger.info(
-                s"Successfully imported Rudder node(s) with id(s) : "
+                s"Successfully imported ${n.size} Rudder node(s) with id(s) : "
                   + n.keys.mkString(", ")
-                  + s"\nSuccessfully imported ${n.size} Rudder node(s)."
               )
               *> this.nodes.set(n.toRundeckNodeSet)
         )
@@ -160,7 +161,7 @@ class RudderResourceModelSource(val configuration: Configuration)
    */
   private def getNodesFromRudder(
       config: Configuration
-  ): ZIO[Client, ErrorMsg, Map[NodeId, NodeEntryImpl]] =
+  ): ZIO[SttpClient, ErrorMsg, Map[NodeId, NodeEntryImpl]] =
 
     // not sure if it's better to not update at all if I don't get groups (like here)
     // or keep the old groups with new node infos (I think no), or put empty groups (not sure).
@@ -188,6 +189,45 @@ class RudderResourceModelSource(val configuration: Configuration)
 }
 
 object RudderResourceModelSource {
+
+  private val DangerAcceptInvalidCerts: X509TrustManager =
+    new X509ExtendedTrustManager():
+      override def getAcceptedIssuers: Array[X509Certificate] =
+        Array.empty[X509Certificate]
+
+      override def checkServerTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String
+      ): Unit = ()
+
+      override def checkClientTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String
+      ): Unit = ()
+
+      override def checkClientTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String,
+          socket: Socket
+      ): Unit = ()
+
+      override def checkServerTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String,
+          socket: Socket
+      ): Unit = ()
+
+      override def checkClientTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String,
+          sslEngine: SSLEngine
+      ): Unit = ()
+
+      override def checkServerTrusted(
+          x509Certificates: Array[X509Certificate],
+          s: String,
+          sslEngine: SSLEngine
+      ): Unit = ()
 
   def getGroupForNode(
       groups: Seq[Group]

--- a/src/main/scala/com/normation/rundeck/plugin/resources/rudder/package.scala
+++ b/src/main/scala/com/normation/rundeck/plugin/resources/rudder/package.scala
@@ -22,17 +22,12 @@ import zio.ZIO
 
 package object rudder {
 
+  // Syntactic sugar for ZIO success and failure values
   extension [A](self: A)
     def fail: IO[A, Nothing] =
       ZIO.fail(self)
     def succeed: UIO[A] =
       ZIO.succeed(self)
-
-  extension [A](self: Either[ErrorMsg, A])
-    def toZIO: ZIO[Any, ErrorMsg, A] =
-      self match
-        case Left(err)    => err.fail
-        case Right(value) => value.succeed
 
   /**
    * Just a shorthand for our "that method can fail, so Either it returns an
@@ -40,26 +35,4 @@ package object rudder {
    */
   type Failable[T] = Either[ErrorMsg, T]
 
-  /**
-   * We also define a monadic traversal of a sequence of Failable things for
-   * simplicity.
-   */
-  /*
-  object Traverse {
-    def apply[T, U](
-        seq: Seq[T]
-    )(f: T => Either[ErrorMsg, U]): Failable[Seq[U]] = {
-
-      // that's clearly not the canonical way of doing it!
-      // (simplest way to avoid stack overflow)
-
-      Right(seq.map { x =>
-        f(x) match {
-          case Right(y)  => y
-          case Left(msg) => return Left(msg)
-        }
-      })
-    }
-  }
-   */
 }

--- a/src/test/scala/com/normation/rundeck/plugin/resources/rudder/BuildRundeckNodeTest.scala
+++ b/src/test/scala/com/normation/rundeck/plugin/resources/rudder/BuildRundeckNodeTest.scala
@@ -102,7 +102,7 @@ class BuildRundeckNodeTest extends ZIOSpecDefault {
         expected.getAttributes.put("rudder_information:id", "root")
         expected.getAttributes.put(
           "rudder_information:node_direct_url",
-          "http://127.0.0.1:8080/rudder/secure/nodeManager/searchNodes#{\"nodeId\":\"root\"}"
+          "http://127.0.0.1:8080/rudder/secure/nodeManager/node/root"
         )
         expected.getAttributes.put("rudder_information:node_status", "accepted")
         expected.getAttributes.put("total_ram", "2062548992")

--- a/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQueryIT.scala
+++ b/src/test/scala/com/normation/rundeck/plugin/resources/rudder/RudderAPIQueryIT.scala
@@ -16,17 +16,11 @@
 
 package com.normation.rundeck.plugin.resources.rudder
 
-import zio.Duration
+import sttp.client4.httpclient.zio.HttpClientZioBackend
 import zio.Scope
 import zio.ZIO
 import zio.ZIOAppArgs
 import zio.ZIOAppDefault
-import zio.ZLayer
-import zio.http.Client
-import zio.http.ClientSSLConfig
-import zio.http.DnsResolver
-import zio.http.ZClient
-import zio.http.netty.NettyConfig
 
 class RudderAPIQueryIT
 
@@ -44,15 +38,6 @@ object RudderAPIQueryIT extends ZIOAppDefault {
 
   override def run: ZIO[Any & ZIOAppArgs & Scope, Any, Any] =
 
-    val clientConfig = ZClient.Config.default
-      .connectionTimeout(
-        Duration.fromSeconds(5)
-      )
-      .ssl(ClientSSLConfig.FromJavaxNetSsl())
-
-    // client defaults, see https://github.com/zio/zio-http/issues/2403
-    val nettyConfig = NettyConfig.defaultWithFastShutdown
-
     for {
       args <- getArgs
       (apiToken, rudderUrl) <-
@@ -65,21 +50,16 @@ object RudderAPIQueryIT extends ZIOAppDefault {
       config = Configuration(
         url = RudderUrl(rudderUrl, ApiLatest),
         apiToken = apiToken,
-        apiTimeout = TimeoutInterval(0),
+        apiTimeout = TimeoutInterval(5),
         checkCertificate = true,
-        refreshInterval = TimeoutInterval(0),
+        refreshInterval = TimeoutInterval(30),
         sshDefaultPort = 8080,
         envVarSSLPort = None,
         rundeckDefaultUser = "rundeck",
         envVarRundeckUser = None
       )
 
-      _ <- program(config).provide(
-        ZLayer.succeed(clientConfig),
-        ZLayer.succeed(nettyConfig),
-        Client.live.orDie,
-        DnsResolver.default
-      )
+      _ <- program(config).provideLayer(HttpClientZioBackend.layer())
     } yield ()
 
 }


### PR DESCRIPTION
#22 

This PR aims to replace the ZIO-Http dependency with sttp.

Notes : 
* The plugin .jar that is produced by maven now has a size of 18.7MB (instead of ~40MB with ZIO-Http)
* The plugin runtime dependencies in the `lib/` folder of the .jar have been renamed : each artifact in the lib folder now has the name `groupId:artifactId` instead of only `artifactId`. This change was made because the `sttp` dependency introduces two artifacts that have the `zio_3` artifactId. Since there was also a `zio_3` artifact because of the dependency to the ZIO library, only one of these artifacts was kept by Maven because their names were identical, resulting in runtime errors.